### PR TITLE
Add Linux Support via Bash Scripts + Batch Fixes + Git Simplification + README Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,23 +30,31 @@ NOTE: You WILL need a modded/hacked console to play this mod on console. I hope 
 Setting up the Amplitude 2016 Deluxe repo for the first time is meant to be as easy as possible.
 As well, it is designed to allow you to automatically receive updates as the repo is updated.
 
-Simply go to the Releases of this repo and grab both files. (one .exe, one .bat)
+Simply go to the Releases of this repo and grab both files (one .exe, one script for your platform: .bat for Windows or .sh for Linux).
 
 The exe is a dependency, [Git for Windows](https://gitforwindows.org/).
 Git is required for you to take advantage of auto updating via github pulls.
-You can setup git with all default options.
+You can setup git with all default options (on Windows), or install via your distro's package manager (Linux).
 
-Once the dependency is installed, run `_init_repo.bat` in an **empty folder**. git will pull the repo and make sure you are completely up to date.
+Once the dependency is installed, run `_init_repo.bat` (on Windows) or `_init_repo.sh` (on Linux) in an **empty folder**. git will pull the repo and make sure you are completely up to date.
 
-After Running `_init_repo.bat`, extract your Amplitude 2016 .ark and .hdr files to the `_prep_ps3` or `_prep_ps4` folder, depending on your console.
+After running the init script, extract your Amplitude 2016 .ark and .hdr files to the `_prep_ps3` or `_prep_ps4` folder, depending on your console.
 
-To build Amplitude 2016 deluxe with new [custom songs](#Songs), run `_build_ps3.bat` or `_build_ps4.bat` depending on the console you are building for. This script will pull the repo for updates, build the ARK for you, and spit it out in `_build/ps3` or `_build/ps4`.
+To build Amplitude 2016 deluxe with new [custom songs](#Songs), run the appropriate script:
+* Windows: `_build_ps3.bat` or `_build_ps4.bat`, depending on the console you are building for.
+* Linux: `_build_ps3.sh` or `_build_ps4.sh`, depending on the console you are building for.
 
-You can also run `_build_ps3_nosong.bat` or `_build_ps4_nosong.bat` depending on the console you are building for. This script will **NOT** update the song list, so if you [added new customs](#Songs), they **WON'T** be included. This script will pull the repo for updates, build the ARK for you, and spit it out in `_build/ps3` or `_build/ps4`.
+These scripts will pull the repo for updates, build the ARK for you, and spit it out in `_build/ps3` or `_build/ps4`.
 
-For PS3/RPCS3, After the build bat is done, copy everything in `_build/ps3` to `dev_hdd0/game/NPUB31810` for US and `dev_hdd0/game/NPEB02398` for EU.
+You can also run:
+* Windows: `_build_ps3_nosong.bat` or `_build_ps4_nosong.bat`, depending on the console you are building for.
+* Linux: `_build_ps3_nosong.sh` or `_build_ps4_nosong.sh`, depending on the console you are building for.
 
-For PS4, After the build bat is done, install the `amp16dx_afr_blank.pkg` file found in `_build/ps4` to your PS4, and copy the rest of the files in `_build/ps4` to the `data/GoldHEN` folder on your ps4.
+These versions will **NOT** update the song list, so if you [added new customs](#Songs), they **WON'T** be included. They will still pull the repo for updates, build the ARK for you, and spit it out in `_build/ps3` or `_build/ps4`.
+
+For PS3/RPCS3, After the build script is done, copy everything in `_build/ps3` to `dev_hdd0/game/NPUB31810` for US and `dev_hdd0/game/NPEB02398` for EU.
+
+For PS4, After the build script is done, install the `amp16dx_afr_blank.pkg` file found in `_build/ps4` to your PS4, and copy the rest of the files in `_build/ps4` to the `data/GoldHEN` folder on your ps4.
 
 If you already have a modified `plugins.ini` in your GoldHEN folder, simply add the following lines to your `plugins.ini`:
 
@@ -65,13 +73,9 @@ Run the build script again to pull any new updates committed to the repo and reb
 
 There is a [repo of custom songs](https://github.com/hmxmilohax/amp-2016-customs) that can be easily added.
 
-To take advantage of these customs, first ensure [python](https://www.python.org/downloads/) is downloaded, and installed into PATH. Click the checkbox presented during python install to ensure this.
+To take advantage of these customs, run `_download_custom_songs.bat` (on Windows) or `_download_custom_songs.sh` (on Linux). This will automatically pull the repo and add the songs to the correct folder
 
-Head to the `dependencies` folder in this repo and run the install_gitpython.bat, or run `pip install gitpython` in cmd.
-
-after that, running `_download_custom_songs.bat` will automatically pull the repo and add the songs to the correct folder
-
-The next time you build Amplitude 2016 Deluxe with `_build_ps#.bat`, the custom songs will show up and be playable.
+The next time you build Amplitude 2016 Deluxe with `_build_ps#.bat`/`_build_ps#.sh`, the custom songs will show up and be playable.
 
 ## Manually-Add
 
@@ -79,7 +83,11 @@ With the help of [AmpHelper](https://github.com/hmxmilohax/AmpHelper) Amplitude 
 
 Simply copy the extracted folder of a custom to `_ark/combined/songs`, making sure to delete any files ending in `_ps3` or `_ps4`.
 
-After that, running  `_build_ps3.bat` or `_build_ps4.bat` will show the new songs that were added when rebuilt.
+After that, run the appropriate script:
+* Windows: `_build_ps3.bat` or `_build_ps4.bat`, depending on the console you are building for.
+* Linux: `_build_ps3.sh` or `_build_ps4.sh`, depending on the console you are building for.
+
+This will show the new songs that were added when rebuilt.
 
 # Dependencies
 

--- a/_build_ps3.bat
+++ b/_build_ps3.bat
@@ -10,7 +10,7 @@ for /R "%~dp0_tmpbuild" %%f in (*.dta) do IF NOT "%%~xf" == ".dta_dta_ps3" depen
 for /R "%~dp0_tmpbuild" %%f in (*.script) do IF NOT "%%~xf" == ".script_dta_ps3" dependencies\dtxtool\dtxtool dta2b "%%f" "%%~dpnf.script_dta_ps3" 3
 for /R "%~dp0_tmpbuild" %%f in (*.dta) do IF NOT "%%~xf" == ".dta_dta_ps3" del "%%f"
 for /R "%~dp0_tmpbuild" %%f in (*.script) do IF NOT "%%~xf" == ".script_dta_ps3" del "%%f"
-xcopy /q /e /y _tmpbuild _prep_ps3\ext_ark\ps3
+xcopy /q /e /y _tmpbuild _prep_ps3\ext_ark\ps3\
 for /R "%~dp0_tmpbuild" %%f in (*) do del "%%f"
 rmdir /s /q "%~dp0_tmpbuild"
 echo:Adding songs to Amplitude 2016 Deluxe config...

--- a/_build_ps3.sh
+++ b/_build_ps3.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+cd "$(dirname "$0")"
+
+# Check if wine is installed
+if ! command -v wine &> /dev/null; then
+	echo "- 'wine' is not installed. Please install it and try again."
+	echo
+	read -p "Press enter to exit..."
+	exit 1
+fi
+
+echo "Creating build directories..."
+mkdir -p "./_build/ps3/USRDIR"
+mkdir -p "./_tmpbuild"
+
+git pull 'https://github.com/hmxmilohax/amplitude-2016-deluxe' main
+
+if [[ ! -d "./_prep_ps3/ext_ark/ps3/" ]]; then
+	echo "Preparing to build PS3 For the first time..."
+	echo "Make sure your 1.0 vanilla ark files are in _prep_ps3"
+	mkdir -p "./_prep_ps3/ext_ark"
+	wine "./dependencies/AmpHelper.exe" ark unpack "./_prep_ps3/main_ps3.hdr" "./_prep_ps3/ext_ark"
+fi
+
+echo "Copying Amplitude 2016 Deluxe PS3 files..."
+cp -r "./_ark/ps3/." "./_tmpbuild/"
+cp -r "./_ark/combined/." "./_tmpbuild/"
+
+echo "Converting .dta files..."
+find "./_tmpbuild" -type f -iname "*.dta" ! -iname "*.dta_dta_ps3" | while read -r file; do
+    out="${file%.dta}.dta_dta_ps3"
+    wine "./dependencies/dtxtool/DTXTool.exe" dta2b "$file" "$out" 3
+done
+
+echo "Converting .script files..."
+find _tmpbuild -type f -iname "*.script" ! -iname "*.script_dta_ps3" | while read -r file; do
+    out="${file%.script}.script_dta_ps3"
+    wine "./dependencies/dtxtool/DTXTool.exe" dta2b "$file" "$out" 3
+done
+
+echo "Cleaning up original .dta and .script files..."
+find "./_tmpbuild" -type f -iname "*.dta" ! -iname "*.dta_dta_ps3" -exec rm {} \;
+find "./_tmpbuild" -type f -iname "*.script" ! -iname "*.script_dta_ps3" -exec rm {} \;
+
+echo "Copying processed files to prep directory..."
+mkdir -p "._prep_ps3/ext_ark/ps3"
+cp -r "./_tmpbuild/." "./_prep_ps3/ext_ark/ps3/"
+
+echo "Cleaning up temp files..."
+rm -rf "./_tmpbuild"
+
+echo "Adding songs to Amplitude 2016 Deluxe config..."
+wine "./dependencies/AmpHelper.exe" song add-all "./_prep_ps3/ext_ark" # >/dev/null
+
+echo "Building Amplitude 2016 Deluxe arks..."
+wine "./dependencies/AmpHelper.exe" ark pack "./_prep_ps3/ext_ark" "./_build/ps3/USRDIR/main_ps3.hdr" # >/dev/null
+
+echo "Wrote Amplitude 2016 Deluxe arks."
+echo "Complete! Enjoy Amplitude 2016 Deluxe"
+read -p "Press enter to exit..."
+exit 0

--- a/_build_ps3.sh
+++ b/_build_ps3.sh
@@ -37,7 +37,7 @@ find "./_tmpbuild" -type f -iname "*.dta" ! -iname "*.dta_dta_ps3" | while read 
 done
 
 echo "Converting .script files..."
-find _tmpbuild -type f -iname "*.script" ! -iname "*.script_dta_ps3" | while read -r file; do
+find "./_tmpbuild" -type f -iname "*.script" ! -iname "*.script_dta_ps3" | while read -r file; do
     out="${file%.script}.script_dta_ps3"
     wine "./dependencies/dtxtool/DTXTool.exe" dta2b "$file" "$out" 3
 done
@@ -47,7 +47,7 @@ find "./_tmpbuild" -type f -iname "*.dta" ! -iname "*.dta_dta_ps3" -exec rm {} \
 find "./_tmpbuild" -type f -iname "*.script" ! -iname "*.script_dta_ps3" -exec rm {} \;
 
 echo "Copying processed files to prep directory..."
-mkdir -p "._prep_ps3/ext_ark/ps3"
+mkdir -p "./_prep_ps3/ext_ark/ps3"
 cp -r "./_tmpbuild/." "./_prep_ps3/ext_ark/ps3/"
 
 echo "Cleaning up temp files..."

--- a/_build_ps3_nosong.bat
+++ b/_build_ps3_nosong.bat
@@ -11,7 +11,7 @@ for /R "%~dp0_tmpbuild" %%f in (*.dta) do IF NOT "%%~xf" == ".dta_dta_ps3" depen
 for /R "%~dp0_tmpbuild" %%f in (*.script) do IF NOT "%%~xf" == ".script_dta_ps3" dependencies\dtxtool\dtxtool dta2b "%%f" "%%~dpnf.script_dta_ps3" 3
 for /R "%~dp0_tmpbuild" %%f in (*.dta) do IF NOT "%%~xf" == ".dta_dta_ps3" del "%%f"
 for /R "%~dp0_tmpbuild" %%f in (*.script) do IF NOT "%%~xf" == ".script_dta_ps3" del "%%f"
-xcopy /q /e /y _tmpbuild _prep_ps3\ext_ark\ps3
+xcopy /q /e /y _tmpbuild _prep_ps3\ext_ark\ps3\
 for /R "%~dp0_tmpbuild" %%f in (*) do del "%%f"
 rmdir /s /q "%~dp0_tmpbuild"
 echo:Building Amplitude 2016 Deluxe arks without new songs...

--- a/_build_ps3_nosong.sh
+++ b/_build_ps3_nosong.sh
@@ -39,7 +39,7 @@ find "./_tmpbuild" -type f -iname "*.dta" ! -iname "*.dta_dta_ps3" | while read 
 done
 
 echo "Converting .script files..."
-find _tmpbuild -type f -iname "*.script" ! -iname "*.script_dta_ps3" | while read -r file; do
+find "./_tmpbuild" -type f -iname "*.script" ! -iname "*.script_dta_ps3" | while read -r file; do
     out="${file%.script}.script_dta_ps3"
     wine "./dependencies/dtxtool/DTXTool.exe" dta2b "$file" "$out" 3
 done
@@ -49,7 +49,7 @@ find "./_tmpbuild" -type f -iname "*.dta" ! -iname "*.dta_dta_ps3" -exec rm {} \
 find "./_tmpbuild" -type f -iname "*.script" ! -iname "*.script_dta_ps3" -exec rm {} \;
 
 echo "Copying processed files to prep directory..."
-mkdir -p "._prep_ps3/ext_ark/ps3"
+mkdir -p "./_prep_ps3/ext_ark/ps3"
 cp -r "./_tmpbuild/." "./_prep_ps3/ext_ark/ps3/"
 
 echo "Cleaning up temp files..."

--- a/_build_ps3_nosong.sh
+++ b/_build_ps3_nosong.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+cd "$(dirname "$0")"
+
+# Check if wine is installed
+if ! command -v wine &> /dev/null; then
+	echo "- 'wine' is not installed. Please install it and try again."
+	echo
+	read -p "Press enter to exit..."
+	exit 1
+fi
+
+echo "Creating build directories..."
+mkdir -p "./_build/ps3/USRDIR"
+mkdir -p "./_tmpbuild"
+
+git pull 'https://github.com/hmxmilohax/amplitude-2016-deluxe' main
+
+if [[ ! -d "./_prep_ps3/ext_ark/ps3/" ]]; then
+	echo "Preparing to build PS3 For the first time..."
+	echo "Make sure your 1.0 vanilla ark files are in _prep_ps3"
+	mkdir -p "./_prep_ps3/ext_ark"
+	wine "./dependencies/AmpHelper.exe" ark unpack "./_prep_ps3/main_ps3.hdr" "./_prep_ps3/ext_ark"
+fi
+
+echo "Copying Amplitude 2016 Deluxe PS3 files..."
+cp -r "./_ark/ps3/." "./_tmpbuild/"
+cp -r "./_ark/combined/." "./_tmpbuild/"
+
+rm -rf "./_tmpbuild/songs/"
+
+echo "Converting .dta files..."
+find "./_tmpbuild" -type f -iname "*.dta" ! -iname "*.dta_dta_ps3" | while read -r file; do
+    out="${file%.dta}.dta_dta_ps3"
+    wine "./dependencies/dtxtool/DTXTool.exe" dta2b "$file" "$out" 3
+done
+
+echo "Converting .script files..."
+find _tmpbuild -type f -iname "*.script" ! -iname "*.script_dta_ps3" | while read -r file; do
+    out="${file%.script}.script_dta_ps3"
+    wine "./dependencies/dtxtool/DTXTool.exe" dta2b "$file" "$out" 3
+done
+
+echo "Cleaning up original .dta and .script files..."
+find "./_tmpbuild" -type f -iname "*.dta" ! -iname "*.dta_dta_ps3" -exec rm {} \;
+find "./_tmpbuild" -type f -iname "*.script" ! -iname "*.script_dta_ps3" -exec rm {} \;
+
+echo "Copying processed files to prep directory..."
+mkdir -p "._prep_ps3/ext_ark/ps3"
+cp -r "./_tmpbuild/." "./_prep_ps3/ext_ark/ps3/"
+
+echo "Cleaning up temp files..."
+rm -rf "./_tmpbuild"
+
+echo "Building Amplitude 2016 Deluxe arks without new songs..."
+wine "./dependencies/AmpHelper.exe" ark pack "./_prep_ps3/ext_ark" "./_build/ps3/USRDIR/main_ps3.hdr" # >/dev/null
+
+echo "Wrote Amplitude 2016 Deluxe arks."
+echo "Complete! Enjoy Amplitude 2016 Deluxe"
+read -p "Press enter to exit..."
+exit 0

--- a/_build_ps4.bat
+++ b/_build_ps4.bat
@@ -10,7 +10,7 @@ for /R "%~dp0_tmpbuild" %%f in (*.dta) do IF NOT "%%~xf" == ".dta_dta_ps4" depen
 for /R "%~dp0_tmpbuild" %%f in (*.script) do IF NOT "%%~xf" == ".script_dta_ps4" dependencies\dtxtool\dtxtool dta2b "%%f" "%%~dpnf.script_dta_ps4" 3
 for /R "%~dp0_tmpbuild" %%f in (*.dta) do IF NOT "%%~xf" == ".dta_dta_ps4" del "%%f"
 for /R "%~dp0_tmpbuild" %%f in (*.script) do IF NOT "%%~xf" == ".script_dta_ps4" del "%%f"
-xcopy /q /e /y _tmpbuild _prep_ps4\ext_ark\ps4
+xcopy /q /e /y _tmpbuild _prep_ps4\ext_ark\ps4\
 for /R "%~dp0_tmpbuild" %%f in (*) do del "%%f"
 rmdir /s /q "%~dp0_tmpbuild"
 echo:Adding songs to Amplitude 2016 Deluxe config...

--- a/_build_ps4.bat
+++ b/_build_ps4.bat
@@ -1,4 +1,5 @@
 @echo off
+mkdir _build\ps4\AFR\CUSA02480
 mkdir _tmpbuild
 git pull https://github.com/hmxmilohax/amplitude-2016-deluxe main
 IF NOT EXIST "%~dp0_prep_ps4\ext_ark\ps4" CALL dev_scripts\!prep_ps4.bat
@@ -13,7 +14,7 @@ xcopy /q /e /y _tmpbuild _prep_ps4\ext_ark\ps4
 for /R "%~dp0_tmpbuild" %%f in (*) do del "%%f"
 rmdir /s /q "%~dp0_tmpbuild"
 echo:Adding songs to Amplitude 2016 Deluxe config...
-"%~dp0dependencies\amphelper" song add-all "%~dp0_prep_ps4\ext_ark". >nul
+"%~dp0dependencies\amphelper" song add-all "%~dp0_prep_ps4\ext_ark" >nul
 echo:Building Amplitude 2016 Deluxe arks...
 "%~dp0dependencies\amphelper" ark pack "%~dp0_prep_ps4\ext_ark" "%~dp0_build\ps4\AFR\CUSA02480\main_ps4.hdr" >nul
 echo:Wrote Amplitude 2016 Deluxe arks.

--- a/_build_ps4.sh
+++ b/_build_ps4.sh
@@ -37,7 +37,7 @@ find "./_tmpbuild" -type f -iname "*.dta" ! -iname "*.dta_dta_ps4" | while read 
 done
 
 echo "Converting .script files..."
-find _tmpbuild -type f -iname "*.script" ! -iname "*.script_dta_ps4" | while read -r file; do
+find "./_tmpbuild" -type f -iname "*.script" ! -iname "*.script_dta_ps4" | while read -r file; do
     out="${file%.script}.script_dta_ps4"
     wine "./dependencies/dtxtool/DTXTool.exe" dta2b "$file" "$out" 3
 done
@@ -47,7 +47,7 @@ find "./_tmpbuild" -type f -iname "*.dta" ! -iname "*.dta_dta_ps4" -exec rm {} \
 find "./_tmpbuild" -type f -iname "*.script" ! -iname "*.script_dta_ps4" -exec rm {} \;
 
 echo "Copying processed files to prep directory..."
-mkdir -p "._prep_ps4/ext_ark/ps4"
+mkdir -p "./_prep_ps4/ext_ark/ps4"
 cp -r "./_tmpbuild/." "./_prep_ps4/ext_ark/ps4/"
 
 echo "Cleaning up temp files..."

--- a/_build_ps4.sh
+++ b/_build_ps4.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+cd "$(dirname "$0")"
+
+# Check if wine is installed
+if ! command -v wine &> /dev/null; then
+	echo "- 'wine' is not installed. Please install it and try again."
+	echo
+	read -p "Press enter to exit..."
+	exit 1
+fi
+
+echo "Creating build directories..."
+mkdir -p "./_build/ps4/AFR/CUSA02480"
+mkdir -p "./_tmpbuild"
+
+git pull 'https://github.com/hmxmilohax/amplitude-2016-deluxe' main
+
+if [[ ! -d "./_prep_ps4/ext_ark/ps4/" ]]; then
+	echo "Preparing to build PS4 For the first time..."
+	echo "Make sure your 1.0 vanilla ark files are in _prep_ps4"
+	mkdir -p "./_prep_ps4/ext_ark"
+	wine "./dependencies/AmpHelper.exe" ark unpack "./_prep_ps4/main_ps4.hdr" "./_prep_ps4/ext_ark"
+fi
+
+echo "Copying Amplitude 2016 Deluxe PS4 files..."
+cp -r "./_ark/ps4/." "./_tmpbuild/"
+cp -r "./_ark/combined/." "./_tmpbuild/"
+
+echo "Converting .dta files..."
+find "./_tmpbuild" -type f -iname "*.dta" ! -iname "*.dta_dta_ps4" | while read -r file; do
+    out="${file%.dta}.dta_dta_ps4"
+    wine "./dependencies/dtxtool/DTXTool.exe" dta2b "$file" "$out" 3
+done
+
+echo "Converting .script files..."
+find _tmpbuild -type f -iname "*.script" ! -iname "*.script_dta_ps4" | while read -r file; do
+    out="${file%.script}.script_dta_ps4"
+    wine "./dependencies/dtxtool/DTXTool.exe" dta2b "$file" "$out" 3
+done
+
+echo "Cleaning up original .dta and .script files..."
+find "./_tmpbuild" -type f -iname "*.dta" ! -iname "*.dta_dta_ps4" -exec rm {} \;
+find "./_tmpbuild" -type f -iname "*.script" ! -iname "*.script_dta_ps4" -exec rm {} \;
+
+echo "Copying processed files to prep directory..."
+mkdir -p "._prep_ps4/ext_ark/ps4"
+cp -r "./_tmpbuild/." "./_prep_ps4/ext_ark/ps4/"
+
+echo "Cleaning up temp files..."
+rm -rf "./_tmpbuild"
+
+echo "Adding songs to Amplitude 2016 Deluxe config..."
+wine "./dependencies/AmpHelper.exe" song add-all "./_prep_ps4/ext_ark" # >/dev/null
+
+echo "Building Amplitude 2016 Deluxe arks..."
+wine "./dependencies/AmpHelper.exe" ark pack "./_prep_ps4/ext_ark" "./_build/ps4/AFR/CUSA02480/main_ps4.hdr" # >/dev/null
+
+echo "Wrote Amplitude 2016 Deluxe arks."
+echo "Complete! Enjoy Amplitude 2016 Deluxe"
+read -p "Press enter to exit..."
+exit 0

--- a/_build_ps4_nosong.bat
+++ b/_build_ps4_nosong.bat
@@ -1,4 +1,5 @@
 @echo off
+mkdir _build\ps4\AFR\CUSA02480
 mkdir _tmpbuild
 git pull https://github.com/hmxmilohax/amplitude-2016-deluxe main
 IF NOT EXIST "%~dp0_prep_ps4\ext_ark\ps4" CALL dev_scripts\!prep_ps4.bat

--- a/_build_ps4_nosong.bat
+++ b/_build_ps4_nosong.bat
@@ -11,7 +11,7 @@ for /R "%~dp0_tmpbuild" %%f in (*.dta) do IF NOT "%%~xf" == ".dta_dta_ps4" depen
 for /R "%~dp0_tmpbuild" %%f in (*.script) do IF NOT "%%~xf" == ".script_dta_ps4" dependencies\dtxtool\dtxtool dta2b "%%f" "%%~dpnf.script_dta_ps4" 3
 for /R "%~dp0_tmpbuild" %%f in (*.dta) do IF NOT "%%~xf" == ".dta_dta_ps4" del "%%f"
 for /R "%~dp0_tmpbuild" %%f in (*.script) do IF NOT "%%~xf" == ".script_dta_ps4" del "%%f"
-xcopy /q /e /y _tmpbuild _prep_ps4\ext_ark\ps4
+xcopy /q /e /y _tmpbuild _prep_ps4\ext_ark\ps4\
 for /R "%~dp0_tmpbuild" %%f in (*) do del "%%f"
 rmdir /s /q "%~dp0_tmpbuild"
 echo:Building Amplitude 2016 Deluxe arks without new songs...

--- a/_build_ps4_nosong.sh
+++ b/_build_ps4_nosong.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+cd "$(dirname "$0")"
+
+# Check if wine is installed
+if ! command -v wine &> /dev/null; then
+	echo "- 'wine' is not installed. Please install it and try again."
+	echo
+	read -p "Press enter to exit..."
+	exit 1
+fi
+
+echo "Creating build directories..."
+mkdir -p "./_build/ps4/AFR/CUSA02480"
+mkdir -p "./_tmpbuild"
+
+git pull 'https://github.com/hmxmilohax/amplitude-2016-deluxe' main
+
+if [[ ! -d "./_prep_ps4/ext_ark/ps4/" ]]; then
+	echo "Preparing to build PS4 For the first time..."
+	echo "Make sure your 1.0 vanilla ark files are in _prep_ps4"
+	mkdir -p "./_prep_ps4/ext_ark"
+	wine "./dependencies/AmpHelper.exe" ark unpack "./_prep_ps4/main_ps4.hdr" "./_prep_ps4/ext_ark"
+fi
+
+echo "Copying Amplitude 2016 Deluxe PS4 files..."
+cp -r "./_ark/ps4/"* "./_tmpbuild/"
+cp -r "./_ark/combined/"* "./_tmpbuild/"
+
+rm -rf "./_tmpbuild/songs/"
+
+echo "Converting .dta files..."
+find "./_tmpbuild" -type f -iname "*.dta" ! -iname "*.dta_dta_ps4" | while read -r file; do
+    out="${file%.dta}.dta_dta_ps4"
+    wine "./dependencies/dtxtool/DTXTool.exe" dta2b "$file" "$out" 3
+done
+
+echo "Converting .script files..."
+find _tmpbuild -type f -iname "*.script" ! -iname "*.script_dta_ps4" | while read -r file; do
+    out="${file%.script}.script_dta_ps4"
+    wine "./dependencies/dtxtool/DTXTool.exe" dta2b "$file" "$out" 3
+done
+
+echo "Cleaning up original .dta and .script files..."
+find "./_tmpbuild" -type f -iname "*.dta" ! -iname "*.dta_dta_ps4" -exec rm {} \;
+find "./_tmpbuild" -type f -iname "*.script" ! -iname "*.script_dta_ps4" -exec rm {} \;
+
+echo "Copying processed files to prep directory..."
+mkdir -p "._prep_ps4/ext_ark/ps4"
+cp -r "./_tmpbuild/"* "./_prep_ps4/ext_ark/ps4/"
+
+echo "Cleaning up temp files..."
+rm -rf "./_tmpbuild"
+
+echo "Building Amplitude 2016 Deluxe arks..."
+wine "./dependencies/AmpHelper.exe" ark pack "./_prep_ps4/ext_ark" "./_build/ps4/AFR/CUSA02480/main_ps4.hdr" # >/dev/null
+
+echo "Wrote Amplitude 2016 Deluxe arks."
+echo "Complete! Enjoy Amplitude 2016 Deluxe"
+read -p "Press enter to exit..."
+exit 0

--- a/_build_ps4_nosong.sh
+++ b/_build_ps4_nosong.sh
@@ -39,7 +39,7 @@ find "./_tmpbuild" -type f -iname "*.dta" ! -iname "*.dta_dta_ps4" | while read 
 done
 
 echo "Converting .script files..."
-find _tmpbuild -type f -iname "*.script" ! -iname "*.script_dta_ps4" | while read -r file; do
+find "./_tmpbuild" -type f -iname "*.script" ! -iname "*.script_dta_ps4" | while read -r file; do
     out="${file%.script}.script_dta_ps4"
     wine "./dependencies/dtxtool/DTXTool.exe" dta2b "$file" "$out" 3
 done
@@ -49,7 +49,7 @@ find "./_tmpbuild" -type f -iname "*.dta" ! -iname "*.dta_dta_ps4" -exec rm {} \
 find "./_tmpbuild" -type f -iname "*.script" ! -iname "*.script_dta_ps4" -exec rm {} \;
 
 echo "Copying processed files to prep directory..."
-mkdir -p "._prep_ps4/ext_ark/ps4"
+mkdir -p "./_prep_ps4/ext_ark/ps4"
 cp -r "./_tmpbuild/"* "./_prep_ps4/ext_ark/ps4/"
 
 echo "Cleaning up temp files..."

--- a/_build_ps4_nosong.sh
+++ b/_build_ps4_nosong.sh
@@ -27,8 +27,8 @@ if [[ ! -d "./_prep_ps4/ext_ark/ps4/" ]]; then
 fi
 
 echo "Copying Amplitude 2016 Deluxe PS4 files..."
-cp -r "./_ark/ps4/"* "./_tmpbuild/"
-cp -r "./_ark/combined/"* "./_tmpbuild/"
+cp -r "./_ark/ps4/." "./_tmpbuild/"
+cp -r "./_ark/combined/." "./_tmpbuild/"
 
 rm -rf "./_tmpbuild/songs/"
 
@@ -50,7 +50,7 @@ find "./_tmpbuild" -type f -iname "*.script" ! -iname "*.script_dta_ps4" -exec r
 
 echo "Copying processed files to prep directory..."
 mkdir -p "./_prep_ps4/ext_ark/ps4"
-cp -r "./_tmpbuild/"* "./_prep_ps4/ext_ark/ps4/"
+cp -r "./_tmpbuild/." "./_prep_ps4/ext_ark/ps4/"
 
 echo "Cleaning up temp files..."
 rm -rf "./_tmpbuild"

--- a/_disable_blackbg.bat
+++ b/_disable_blackbg.bat
@@ -7,7 +7,7 @@ rd "%~dp0_ark\ps3\world\shared\geo"
 rd "%~dp0_ark\ps3\world\shared\shaders"
 rd "%~dp0_ark\ps3\world\shared"
 rd "%~dp0_ark\ps3\world"
-xcopy /e /y "%~dp0dx_optional_additions\_revert_to_default\ps3blkbg" "%~dp0_ark\ps3\world
+xcopy /e /y "%~dp0dx_optional_additions\_revert_to_default\ps3blkbg" "%~dp0_ark\ps3\world\"
 FOR /R "%~dp0_ark\ps4\world" %%f in (*) do DEL %%f
 rd "%~dp0_ark\ps4\world\world_01"
 rd "%~dp0_ark\ps4\world\world_02"
@@ -17,5 +17,5 @@ rd "%~dp0_ark\ps4\world\shared\geo"
 rd "%~dp0_ark\ps4\world\shared\shaders"
 rd "%~dp0_ark\ps4\world\shared"
 rd "%~dp0_ark\ps4\world"
-xcopy /e /y "%~dp0dx_optional_additions\_revert_to_default\ps4blkbg" "%~dp0_ark\ps4\world
+xcopy /e /y "%~dp0dx_optional_additions\_revert_to_default\ps4blkbg" "%~dp0_ark\ps4\world\"
 pause

--- a/_disable_blackbg.bat
+++ b/_disable_blackbg.bat
@@ -7,7 +7,7 @@ rd "%~dp0_ark\ps3\world\shared\geo"
 rd "%~dp0_ark\ps3\world\shared\shaders"
 rd "%~dp0_ark\ps3\world\shared"
 rd "%~dp0_ark\ps3\world"
-xcopy /e /y "%~dp0dx_optional_additions\_revert_to_default\ps3blkbg" "%~dp0_build\prep\ps3\ps3\world
+xcopy /e /y "%~dp0dx_optional_additions\_revert_to_default\ps3blkbg" "%~dp0_ark\ps3\world
 FOR /R "%~dp0_ark\ps4\world" %%f in (*) do DEL %%f
 rd "%~dp0_ark\ps4\world\world_01"
 rd "%~dp0_ark\ps4\world\world_02"
@@ -17,5 +17,5 @@ rd "%~dp0_ark\ps4\world\shared\geo"
 rd "%~dp0_ark\ps4\world\shared\shaders"
 rd "%~dp0_ark\ps4\world\shared"
 rd "%~dp0_ark\ps4\world"
-xcopy /e /y "%~dp0dx_optional_additions\_revert_to_default\ps4blkbg" "%~dp0_build\prep\ps4\ps4\world
+xcopy /e /y "%~dp0dx_optional_additions\_revert_to_default\ps4blkbg" "%~dp0_ark\ps4\world
 pause

--- a/_disable_blackbg.sh
+++ b/_disable_blackbg.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")"
+
+echo "Disabling Black Background"
+if [[ -d "./_ark/ps3/world/" ]]; then
+	rm -rf "./_ark/ps3/world/"
+fi
+mkdir -p "./_ark/ps3/world/"
+cp -r "./dx_optional_additions/_revert_to_default/ps3blkbg/." "./_ark/ps3/world/"
+
+if [[ -d "./_ark/ps4/world/" ]]; then
+	rm -rf "./_ark/ps4/world/"
+fi
+mkdir -p "./_ark/ps4/world/"
+cp -r "./dx_optional_additions/_revert_to_default/ps4blkbg/." "./_ark/ps4/world/"
+
+echo
+read -p "Done! Press any key to continue..."
+exit 0

--- a/_download_custom_songs.bat
+++ b/_download_custom_songs.bat
@@ -1,3 +1,43 @@
-rmdir /s /q "%~dp0\_ark\combined\songs"
-python dependencies/download_songs.py
+REM rmdir /s /q "%~dp0\_ark\combined\songs"
+REM python dependencies/download_songs.py
+REM pause
+
+@echo off
+setlocal enabledelayedexpansion
+
+cd /d "%~dp0"
+
+REM Check if git is installed
+where git >nul 2>nul
+if errorlevel 1 (
+    echo - 'git' is not installed. Please install Git from https://git-scm.com/downloads
+    echo.
+    pause
+    exit /b 1
+)
+
+REM Clone or update the repo
+echo.
+if not exist ".\amp-2016-customs\.git" (
+    echo - Downloading additional Amp 2016 custom songs, this may take some time.
+    git clone --branch main https://github.com/jnackmclain/amp-2016-customs.git ".\amp-2016-customs"
+) else (
+    echo - Updating additional Amp 2016 custom songs.
+    cd ".\amp-2016-customs"
+    git pull origin main
+    cd ..
+)
+
+REM Remove existing destination folder
+if exist ".\_ark\combined\songs\" (
+    rmdir /s /q ".\_ark\combined\songs\"
+)
+
+REM Copy songs directory
+xcopy ".\amp-2016-customs\songs" ".\_ark\combined\songs\" /s /e /i /y
+
+echo.
+echo - Successfully downloaded Amp 2016 custom songs repo. Please rebuild in order to see them added in-game.
+echo.
 pause
+exit /b 0

--- a/_download_custom_songs.bat
+++ b/_download_custom_songs.bat
@@ -1,8 +1,10 @@
+@echo off
+
 REM rmdir /s /q "%~dp0\_ark\combined\songs"
 REM python dependencies/download_songs.py
 REM pause
+REM exit /b 0
 
-@echo off
 setlocal enabledelayedexpansion
 
 cd /d "%~dp0"

--- a/_download_custom_songs.sh
+++ b/_download_custom_songs.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e # Exit on error
+
+cd "$(dirname "$0")"
+
+# Check if git is installed
+if ! command -v git &> /dev/null; then
+	echo "- 'git' is not installed. Please install it and try again."
+	echo
+	read -p "Press enter to exit..."
+	exit 1
+fi
+
+# Clone or update the repo
+echo
+if [[ ! -d "./amp-2016-customs/.git" ]]; then
+	echo "- Downloading additional Amp 2016 custom songs, this may take some time."
+	git clone --branch main https://github.com/jnackmclain/amp-2016-customs.git "./amp-2016-customs"
+else
+	echo "- Updating additional Amp 2016 custom songs."
+	cd "./amp-2016-customs"
+	git pull origin main
+	cd ..
+fi
+
+# Remove existing destination folder
+if [[ -d "./_ark/combined/songs/" ]]; then
+	rm -rf "./_ark/combined/songs/"
+fi
+
+# Copy songs directory
+cp -r "./amp-2016-customs/songs" "./_ark/combined/songs/"
+
+echo
+echo "- Successfully downloaded Amp 2016 custom songs repo. Please rebuild in order to see them added in-game."
+echo
+read -p "Press enter to exit..."
+exit 0

--- a/_emu_unlock_fps.sh
+++ b/_emu_unlock_fps.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")"
+
+echo "Unlocking FPS on Emulator"
+rm "./_ark/ps3/system/data/config/default.dta"
+cp "./dx_optional_additions/emu_unlock_fps/default.dta" "./_ark/ps3/system/data/config/"
+
+echo
+read -p "Done! Press any key to continue..."
+exit 0

--- a/_enable_blackbg.bat
+++ b/_enable_blackbg.bat
@@ -1,5 +1,5 @@
 md "%~dp0_ark\ps3\world"
-xcopy /e /y dx_optional_additions\blackbg\ps3 _ark\ps3\world
+xcopy /e /y dx_optional_additions\blackbg\ps3 _ark\ps3\world\
 md "%~dp0_ark\ps4\world"
-xcopy /e /y dx_optional_additions\blackbg\ps4 _ark\ps4\world
+xcopy /e /y dx_optional_additions\blackbg\ps4 _ark\ps4\world\
 pause

--- a/_enable_blackbg.sh
+++ b/_enable_blackbg.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")"
+
+echo "Enabling Black Background"
+if [[ -d "./_ark/ps3/world/" ]]; then
+	rm -rf "./_ark/ps3/world/"
+fi
+mkdir -p "./_ark/ps3/world/"
+cp -r "./dx_optional_additions/blackbg/ps3/." "./_ark/ps3/world/"
+
+if [[ -d "./_ark/ps4/world/" ]]; then
+	rm -rf "./_ark/ps4/world/"
+fi
+mkdir -p "./_ark/ps4/world/"
+cp -r "./dx_optional_additions/blackbg/ps4/." "./_ark/ps4/world/"
+
+echo
+read -p "Done! Press any key to continue..."
+exit 0

--- a/_lock_fps.sh
+++ b/_lock_fps.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")"
+
+echo "Locking FPS"
+rm "./_ark/ps3/system/data/config/default.dta"
+cp "./dx_optional_additions/_revert_to_default/default.dta" "./_ark/ps3/system/data/config/"
+
+echo
+read -p "Done! Press any key to continue..."
+exit 0

--- a/_z_clean_ps3.sh
+++ b/_z_clean_ps3.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")"
+
+rm -rf "./_prep_ps3/ext_ark"
+echo "The PS3 prep folder has been removed."
+
+echo
+read -p "Press any key to continue..."
+exit 0

--- a/_z_clean_ps4.sh
+++ b/_z_clean_ps4.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")"
+
+rm -rf "./_prep_ps4/ext_ark"
+echo "The PS4 prep folder has been removed."
+
+echo
+read -p "Press any key to continue..."
+exit 0

--- a/dependencies/download_songs.py
+++ b/dependencies/download_songs.py
@@ -2,29 +2,34 @@
 from pathlib import Path
 import shutil
 import os
+import sys
+
 try:
     import git
+    from git.exc import GitCommandError
     print("module 'git' is installed. Downloading/enabling additional Amp 2016 custom songs, this may take some time.")
 except ModuleNotFoundError:
     print("module 'git' is not installed. Install it via '/dependencies/install_gitpython.bat' or 'pip install gitpython'")
     sys.exit(1)
-    
+
 # get the current working directory
 cwd = Path().absolute()
 
 # clone/pull amp songs
-amp_songs_source_path = cwd.joinpath("amp-2016-customs")
+amp_songs_source_path = cwd / "amp-2016-customs"
 
 try:
     repo = git.Repo.clone_from("https://github.com/jnackmclain/amp-2016-customs.git", amp_songs_source_path, branch="main")
-except:
+except GitCommandError:
     repo = git.Repo(amp_songs_source_path)
-    origin = repo.remotes.origin
-    origin.pull()
+    repo.remotes.origin.pull()
 
-amp_2016_songs_source_folder = cwd.joinpath("amp-2016-customs/songs")
-amp_2016_customs_folder = cwd.joinpath("_ark/combined/songs")
-files = os.listdir(amp_songs_source_path)
+amp_2016_songs_source_folder = amp_songs_source_path / "songs"
+amp_2016_customs_folder = cwd / "_ark" / "combined" / "songs"
+
+if amp_2016_customs_folder.exists():
+    shutil.rmtree(amp_2016_customs_folder)
+
 shutil.copytree(amp_2016_songs_source_folder, amp_2016_customs_folder)
 
-print(f"Successfully downloaded amp 2016 custom songs repo. Please rebuild in order to see them added in-game.")
+print("Successfully downloaded amp 2016 custom songs repo. Please rebuild in order to see them added in-game.")


### PR DESCRIPTION
Hi!

First off, thank you so much for this awesome project, Amplitude 2016 Deluxe is an amazing piece of work, and I really appreciate the time and effort you've put into making it so accessible and moddable.

Highlights of this PR:
- Added Linux support by introducing Bash script equivalents for the existing Batch scripts.
- Fixed a few issues in some of the existing Batch scripts.
- Replaced Python-based Git usage in scripts with direct Git commands, removing the need for Python (since Git is already required for cloning the repo).
- Still updated the Python script with a few enhancements, just in case it's decided to keep using it.
- Updated the README to reflect cross-platform compatibility and the reduced dependency on Python.

Notes:
- I've only tested the Linux scripts for the PS3 version of the game. PS4 is untested, as I don't have the hardware.
- The fixes to the existing Batch scripts haven't been tested either.
- For now, running the Windows executables (AmpHelper.exe and DTXTool.exe) is possible via Wine. If I get the time, I might try building native Linux versions where possible.
- The "dev_scripts" doesn't yet have Linux versions. I'm unsure if I'll port those, but I'm open to doing it if there's demand.
- The Linux equivalent of the init script would be `_init_repo.sh`:
```
#!/bin/bash

cd "$(dirname "$0")"

git init
git pull 'https://github.com/hmxmilohax/amplitude-2016-deluxe' main

exit 0
```

I'd love it if you could take a look and let me know if everything checks out, or if you'd like any adjustments. Thanks again for all you do!

Best,
KeyofBlueS